### PR TITLE
update distro-base download path; remove race install

### DIFF
--- a/builder-base/scripts/download_golang.sh
+++ b/builder-base/scripts/download_golang.sh
@@ -40,13 +40,6 @@ function build::go::download(){
         fi
     done
 
-    if [ $arch == 'x86_64' ]; then
-        local filename="$outputDir/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm"
-        if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
-        fi
-    fi
-
     for artifact in golang-docs golang-misc golang-tests golang-src; do
         local filename="$outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm"
         if [ ! -f $filename ]; then

--- a/eks-distro-base/scripts/install_golang
+++ b/eks-distro-base/scripts/install_golang
@@ -74,15 +74,15 @@ function build::go::install(){
     fi
 
     for artifact in golang golang-bin; do
-        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
+        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
     done
 
     if [ $TARGETARCH == 'amd64' ]; then 
-        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
+        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
     fi
 
     for artifact in golang-docs golang-misc golang-tests golang-src; do
-        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm
+        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm
     done
 
     build::go::extract $version

--- a/eks-distro-base/scripts/install_golang
+++ b/eks-distro-base/scripts/install_golang
@@ -77,10 +77,6 @@ function build::go::install(){
         build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
     done
 
-    if [ $TARGETARCH == 'amd64' ]; then 
-        build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
-    fi
-
     for artifact in golang-docs golang-misc golang-tests golang-src; do
         build::go::download_rpm https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm
     done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There are actually 2 places we download golang -- one int he builder base, and one in EKS Distro base. These should be unified but for now we just need to update them both with the next path. This updates the eks-distro base path to include the arch path.

We also want to remove the golang race detector install overall -- it's not shipped with Golang 1.20 (see Go Command section of the release notes https://tip.golang.org/doc/go1.20) and our spec doesn't build it, we also don't really need it in these images. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
